### PR TITLE
Introduce multi agent workflow with RAG agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ RAG_HEITAA/
 │       ├── prompt_assembler.py  # Builds prompts from chat + retrieved docs
 │       ├── retriever.py         # Vector-based document retriever
 │       └── session.py           # Maintains multi-turn chat history
+├── agents/                      # Agent implementations
+│   ├── base.py                  # Base agent interface
+│   └── rag_agent.py             # RAG agent using ChatEngine
+├── core/
+│   └── workflow.py              # Multi‑agent workflow orchestrator
+├── utils/
+│   └── logger.py                # Common logging utility
 ├── embedding/
 │   └── embedder.py              # Converts user queries into vector embeddings
 ├── language_model/
-│   └── lm.py                    # GROQ/OpenAI API interface
+│   └── language_model.py        # GROQ/OpenAI API interface
 ├── vector_store/
 │   └── base.py                  # Qdrant-based vector DB wrapper
 ├── main.py                      # Entry point CLI chatbot

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+# Agents package

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,4 @@
+class Agent:
+    """Abstract agent interface."""
+    def act(self, message: str) -> str:
+        raise NotImplementedError("Agents must implement the act method")

--- a/agents/rag_agent.py
+++ b/agents/rag_agent.py
@@ -1,0 +1,22 @@
+from chat_engine.chat_engine import ChatEngine
+from chat_engine.modules.retriever import default_retriever
+from chat_engine.modules.prompt_assembler import default_prompt_assembler
+from embedding.embedder import embed_text
+from language_model.language_model import generate_answer
+
+from .base import Agent
+
+
+class RAGAgent(Agent):
+    """Agent that answers questions using the RAG ChatEngine."""
+
+    def __init__(self):
+        self.engine = ChatEngine(
+            retriever=default_retriever,
+            embedder=embed_text,
+            llm=generate_answer,
+            prompt_assembler=default_prompt_assembler,
+        )
+
+    def act(self, message: str) -> str:
+        return self.engine.answer_query(message)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Core package

--- a/core/workflow.py
+++ b/core/workflow.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from utils.logger import log
+from agents.base import Agent
+
+
+class Workflow:
+    """Simple sequential workflow that runs a list of agents."""
+
+    def __init__(self, agents: List[Agent]):
+        self.agents = agents
+
+    def run(self, message: str) -> str:
+        """Send the message through each agent in sequence."""
+        log(f"Starting workflow with input: {message}")
+        for agent in self.agents:
+            message = agent.act(message)
+            log(f"{agent.__class__.__name__} produced: {message}")
+        return message

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_modules(monkeypatch):
+    """Stub heavy dependencies for workflow tests."""
+    import os
+    project_root = os.path.dirname(os.path.dirname(__file__))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+    # Reuse stubs from test_chat_engine
+    embedding = types.ModuleType("embedding")
+    embedder = types.ModuleType("embedding.embedder")
+    embedder.embed_text = lambda text: [0.1, 0.2]
+    embedding.embedder = embedder
+    monkeypatch.setitem(sys.modules, "embedding", embedding)
+    monkeypatch.setitem(sys.modules, "embedding.embedder", embedder)
+
+    vector_store = types.ModuleType("vector_store")
+    base = types.ModuleType("vector_store.base")
+    class DummyResult:
+        def __init__(self, payload):
+            self.payload = payload
+    base.DummyResult = DummyResult
+    base.query_vector = lambda vec, top_k=5: [DummyResult({"text": "ctx"})]
+    vector_store.base = base
+    monkeypatch.setitem(sys.modules, "vector_store", vector_store)
+    monkeypatch.setitem(sys.modules, "vector_store.base", base)
+
+    language_model = types.ModuleType("language_model")
+    lm_mod = types.ModuleType("language_model.language_model")
+    lm_mod.generate_answer = lambda messages: "assistant response"
+    language_model.language_model = lm_mod
+    monkeypatch.setitem(sys.modules, "language_model", language_model)
+    monkeypatch.setitem(sys.modules, "language_model.language_model", lm_mod)
+
+    yield
+
+
+def test_workflow_runs_with_rag_agent():
+    workflow_module = importlib.import_module("core.workflow")
+    rag_mod = importlib.import_module("agents.rag_agent")
+
+    wf = workflow_module.Workflow([rag_mod.RAGAgent()])
+    output = wf.run("hello")
+    assert output == "assistant response"
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils package

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,3 @@
+def log(message: str) -> None:
+    """Simple logging utility used by the workflow."""
+    print(f"[LOG] {message}")


### PR DESCRIPTION
## Summary
- document new folder layout including `agents`, `core`, and `utils`
- add base `Agent` interface
- implement `RAGAgent` that wraps the existing ChatEngine
- create `Workflow` class as core orchestrator
- provide simple logging utility
- include tests for the workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861842564888323824c2ca9178f90fe