### PR TITLE
Remove extraneous print from deidentifier

### DIFF
--- a/storage/deidentifier.py
+++ b/storage/deidentifier.py
@@ -1,5 +1,6 @@
 # text_cleaning/deid.py
 import spacy
+from utils.logger import log
 
 # Load spaCy model for NER (using a general English model; could use a clinical NER model if available)
 nlp = spacy.load("en_core_web_sm")
@@ -11,7 +12,8 @@ def deidentify_text(text: str) -> str:
     """Remove or mask PHI entities from the input text."""
     doc = nlp(text)
     cleaned_text = text
-    print("✅ deid.py loaded successfully.")
+    # Optional feedback via logging
+    log("deidentifier loaded")
 
     for ent in doc.ents:
         if ent.label_ in PHI_LABELS:


### PR DESCRIPTION
## Summary
- clean up `storage/deidentifier.py` by removing a noisy print
- emit an optional log message using `utils.logger.log`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d4f206608323af7314f175d64550