### PR TITLE
Add multi-agent coordinator and agents

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Vittala Sharvan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ index_document(
 
 ---
 
+## 🤖 Multi-Agent Usage
+
+`MultiAgentCoordinator` lets multiple agents collaborate using a shared
+`context` dictionary. Combine the provided `DeidAgent`, `SummaryAgent`, and
+`RAGAgent` as needed:
+
+```python
+from agents.deid_agent import DeidAgent
+from agents.summary_agent import SummaryAgent
+from agents.rag_agent import RAGAgent
+from core.multi_agent import MultiAgentCoordinator
+
+coordinator = MultiAgentCoordinator([DeidAgent(), SummaryAgent(), RAGAgent()])
+response = coordinator.run("Patient John Doe was admitted yesterday.")
+```
+
+Each agent receives the current message and can store results in the shared
+`context` for the next agent.
+
+---
+
 ## 🧪 Testing
 
 You can manually test:

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,4 +1,9 @@
+from typing import Dict, Tuple
+
+
 class Agent:
-    """Abstract agent interface."""
-    def act(self, message: str) -> str:
+    """Abstract agent interface for all agents."""
+
+    def act(self, message: str, context: Dict) -> Tuple[str, Dict]:
+        """Process a message and update the shared context."""
         raise NotImplementedError("Agents must implement the act method")

--- a/agents/deid_agent.py
+++ b/agents/deid_agent.py
@@ -1,0 +1,13 @@
+from .base import Agent
+
+
+class DeidAgent(Agent):
+    """Agent that deidentifies PHI from the message."""
+
+    def act(self, message: str, context: dict) -> tuple[str, dict]:
+        # Import lazily to avoid heavy startup cost
+        from storage.deidentifier import deidentify_text
+
+        cleaned = deidentify_text(message)
+        context["deidentified"] = cleaned
+        return cleaned, context

--- a/agents/rag_agent.py
+++ b/agents/rag_agent.py
@@ -18,5 +18,8 @@ class RAGAgent(Agent):
             prompt_assembler=default_prompt_assembler,
         )
 
-    def act(self, message: str) -> str:
-        return self.engine.answer_query(message)
+    def act(self, message: str, context: dict) -> tuple[str, dict]:
+        """Answer a question and append the response to context messages."""
+        response = self.engine.answer_query(message)
+        context.setdefault("messages", []).append({"role": "assistant", "content": response})
+        return response, context

--- a/agents/summary_agent.py
+++ b/agents/summary_agent.py
@@ -1,0 +1,10 @@
+from .base import Agent
+
+
+class SummaryAgent(Agent):
+    """Agent that returns a short summary of the message."""
+
+    def act(self, message: str, context: dict) -> tuple[str, dict]:
+        summary = message[:100]
+        context["summary"] = summary
+        return summary, context

--- a/core/multi_agent.py
+++ b/core/multi_agent.py
@@ -1,0 +1,21 @@
+from typing import List, Tuple, Dict
+
+from utils.logger import log
+from agents.base import Agent
+
+
+class MultiAgentCoordinator:
+    """Coordinate multiple agents sharing a mutable context."""
+
+    def __init__(self, agents: List[Agent]):
+        self.agents = agents
+        self.context: Dict = {"messages": []}
+
+    def run(self, message: str) -> str:
+        """Send the message through each agent with shared context."""
+        log(f"Starting multi-agent run with input: {message}")
+        msg = message
+        for agent in self.agents:
+            msg, self.context = agent.act(msg, self.context)
+            log(f"{agent.__class__.__name__} produced: {msg}")
+        return msg

--- a/core/workflow.py
+++ b/core/workflow.py
@@ -11,9 +11,11 @@ class Workflow:
         self.agents = agents
 
     def run(self, message: str) -> str:
-        """Send the message through each agent in sequence."""
+        """Send the message through each agent in sequence with shared context."""
         log(f"Starting workflow with input: {message}")
+        context = {}
+        msg = message
         for agent in self.agents:
-            message = agent.act(message)
-            log(f"{agent.__class__.__name__} produced: {message}")
-        return message
+            msg, context = agent.act(msg, context)
+            log(f"{agent.__class__.__name__} produced: {msg}")
+        return msg

--- a/embedding/embedder.py
+++ b/embedding/embedder.py
@@ -5,9 +5,16 @@ from sentence_transformers import SentenceTransformer
 EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 # For BioBERT, one could use a HuggingFace model like "pritamdeka/BioBERT-mnli-snli" or similar if available
 
-model = SentenceTransformer(EMBEDDING_MODEL)
+_model = None
+
+
+def _get_model() -> SentenceTransformer:
+    global _model
+    if _model is None:
+        _model = SentenceTransformer(EMBEDDING_MODEL)
+    return _model
 
 def embed_text(text: str):
     """Generate a vector embedding for the given text."""
-    # Ensure text is a string (or a list of strings if batch)
+    model = _get_model()
     return model.encode(text)

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from core.multi_agent import MultiAgentCoordinator
+from agents.base import Agent
+
+
+class AgentA(Agent):
+    def act(self, message: str, context: dict):
+        context.setdefault("order", []).append("A")
+        return message + "a", context
+
+
+class AgentB(Agent):
+    def act(self, message: str, context: dict):
+        context.setdefault("order", []).append("B")
+        return message + "b", context
+
+
+def test_multi_agent_coordinator_shared_context():
+    coord = MultiAgentCoordinator([AgentA(), AgentB()])
+    result = coord.run("x")
+    assert result == "xab"
+    assert coord.context["order"] == ["A", "B"]


### PR DESCRIPTION
## Summary
- implement `MultiAgentCoordinator` for shared context between agents
- extend agent interface and RAGAgent
- add `DeidAgent` and `SummaryAgent`
- update workflow and embedder (lazy-load model)
- document multi-agent usage in README
- include MIT License
- add tests for new coordinator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c46926448323ae7c378aad3782c7