### PR TITLE
Implement structured logging, add roadmap tasks

### DIFF
--- a/core/multi_agent.py
+++ b/core/multi_agent.py
@@ -13,9 +13,9 @@ class MultiAgentCoordinator:
 
     def run(self, message: str) -> str:
         """Send the message through each agent with shared context."""
-        log(f"Starting multi-agent run with input: {message}")
+        cid = log(f"Starting multi-agent run with input: {message}")
         msg = message
         for agent in self.agents:
             msg, self.context = agent.act(msg, self.context)
-            log(f"{agent.__class__.__name__} produced: {msg}")
+            log(f"{agent.__class__.__name__} produced: {msg}", cid)
         return msg

--- a/core/workflow.py
+++ b/core/workflow.py
@@ -12,10 +12,10 @@ class Workflow:
 
     def run(self, message: str) -> str:
         """Send the message through each agent in sequence with shared context."""
-        log(f"Starting workflow with input: {message}")
+        cid = log(f"Starting workflow with input: {message}")
         context = {}
         msg = message
         for agent in self.agents:
             msg, context = agent.act(msg, context)
-            log(f"{agent.__class__.__name__} produced: {msg}")
+            log(f"{agent.__class__.__name__} produced: {msg}", cid)
         return msg

--- a/docs/enterprise_roadmap.md
+++ b/docs/enterprise_roadmap.md
@@ -16,7 +16,7 @@ This document outlines potential enhancements to turn **RAG_HEITAA** into a prod
 - **Versioned APIs**: Maintain backward compatibility through explicit versioning.
 
 ## Robust Observability
-- **Structured Logging**: Include correlation IDs in `utils/logger.py` for better tracing.
+- **Structured Logging**: Include correlation IDs in `utils/logger.py` for better tracing. **(Completed)**
 - **Centralized Metrics**: Integrate Prometheus/Grafana dashboards for performance monitoring.
 
 ## Data Governance & Security

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,46 @@
+# Development Tasks
+
+The following tasks are derived from [enterprise_roadmap.md](enterprise_roadmap.md).
+Check completed items when implemented.
+
+## Scalable Backend Architecture
+- [ ] Containerization: Provide Docker images with Qdrant pre-configured
+- [ ] Kubernetes Support: Helm charts for clustering
+- [ ] Async Processing for heavy ingestion or parsing
+
+## Extensible Modular Design
+- [ ] Pluggable Components for embeddings, language models and vector stores
+- [ ] Multi-Strategy Retrieval combining vector search and metadata filters
+
+## Enterprise-Grade APIs
+- [ ] REST/GraphQL Endpoints with authentication
+- [ ] Versioned APIs for backward compatibility
+
+## Robust Observability
+- [x] Structured Logging with correlation IDs
+- [ ] Centralized Metrics via Prometheus/Grafana
+
+## Data Governance & Security
+- [ ] Audit Trails for document ingestion/edit events
+- [ ] Access Control with an identity provider
+- [ ] Encryption for data in transit and at rest
+
+## Enterprise Integrations
+- [ ] Webhooks & Event Bus for ingestion and chat events
+- [ ] Workflow Hooks for custom pre/post processing
+
+## Data Ingestion Pipelines
+- [ ] Batch & Streaming Ingest from sources like S3 or queues
+- [ ] Metadata Enrichment during ingestion
+
+## UI & Collaboration
+- [ ] Central Dashboard for monitoring and logs
+- [ ] Versioned Knowledge Bases with rollback support
+
+## Testing & CI/CD
+- [ ] Unit & Integration Tests covering all modules
+- [ ] Automated Deployment scripts
+
+## Documentation & Samples
+- [ ] API Reference (OpenAPI) and example notebooks
+- [ ] Enterprise Setup Guide

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,3 +1,18 @@
-def log(message: str) -> None:
-    """Simple logging utility used by the workflow."""
-    print(f"[LOG] {message}")
+"""Logging utility with optional correlation IDs for tracing."""
+
+from __future__ import annotations
+
+import uuid
+
+
+def log(message: str, correlation_id: str | None = None) -> str:
+    """Print a log message with a correlation ID.
+
+    If ``correlation_id`` is not provided, a new short UUID is generated.  The
+    correlation ID is returned so callers can reuse it for subsequent log
+    entries.
+    """
+
+    cid = correlation_id or str(uuid.uuid4())[:8]
+    print(f"[{cid}] {message}")
+    return cid


### PR DESCRIPTION
## Summary
- add correlation IDs to `utils.logger`
- propagate correlation ID in workflow and multi-agent
- mark structured logging as completed in enterprise roadmap
- create `docs/tasks.md` with checklist of roadmap items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864d8d8289083239f9186db90b8a081