### PR TITLE
Add docker-compose setup with Qdrant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PYTHONUNBUFFERED=1
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ docker run -p 6333:6333 qdrant/qdrant
 
 Or use [Qdrant Cloud](https://qdrant.tech/).
 
+### 🐳 Docker Compose
+
+A `docker-compose.yml` is provided to launch the app together with a Qdrant
+service. Build and start both containers with:
+
+```bash
+docker compose up --build
+```
+
+The application container will connect to the `qdrant` service automatically
+using the `QDRANT_URL` environment variable.
+
 ---
 
 ## 🧠 How It Works

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+  qdrant:
+    image: qdrant/qdrant
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+  app:
+    build: .
+    depends_on:
+      - qdrant
+    environment:
+      - QDRANT_URL=http://qdrant:6333
+    volumes:
+      - ./input_data:/app/input_data
+    stdin_open: true
+    tty: true
+    command: ["python", "main.py"]
+volumes:
+  qdrant_data:

--- a/vector_store/base.py
+++ b/vector_store/base.py
@@ -2,12 +2,14 @@
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, VectorParams, PointStruct
 from qdrant_client.http.exceptions import UnexpectedResponse
+import os
 
 COLLECTION_NAME = "claims_collection"
 VECTOR_DIMENSION = 384
 DISTANCE_METRIC = Distance.COSINE
 
-client = QdrantClient(url="http://localhost:6333")
+QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
+client = QdrantClient(url=QDRANT_URL)
 
 def init_collection():
     existing = client.get_collections().collections


### PR DESCRIPTION
## Summary
- make Qdrant URL configurable via `QDRANT_URL`
- document Docker Compose usage in README
- add `Dockerfile` for the app
- add `docker-compose.yml` with Qdrant service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864dadc9e908323b8a487e4fcab6cf5