### PR TITLE
Add Helm chart and Celery worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ docker compose up --build
 
 The application container will connect to the `qdrant` service automatically
 using the `QDRANT_URL` environment variable.
+### ☸️ Kubernetes Deployment
+A Helm chart is available in `helm/` for running the API, Qdrant, and workers on Kubernetes. Install with:
+```bash
+helm install rag-heitaa helm
+```
+
+### 🚀 Async Ingestion
+Start a Celery worker to process heavy ingestion jobs:
+```bash
+celery -A async_tasks.tasks worker --loglevel=info
+```
+
 
 ---
 

--- a/async_tasks/__init__.py
+++ b/async_tasks/__init__.py
@@ -1,0 +1,2 @@
+from .tasks import app
+__all__ = ["app"]

--- a/async_tasks/tasks.py
+++ b/async_tasks/tasks.py
@@ -1,0 +1,16 @@
+from celery import Celery
+from embedding.embedder import embed_text
+from parsers.text_parser import parse_txt_folder
+from vector_store.base import index_document, init_collection
+
+app = Celery('rag_tasks', broker='redis://redis:6379/0')
+
+@app.task
+def ingest_folder(folder_path: str):
+    """Parse text files and index them asynchronously."""
+    init_collection()
+    docs = parse_txt_folder(folder_path)
+    for idx, doc in enumerate(docs):
+        vector = embed_text(doc["text"])
+        index_document(doc_id=idx, vector=vector, payload={"text": doc["text"], "source": doc["source"]})
+    return len(docs)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,31 @@ services:
       - "6333:6333"
     volumes:
       - qdrant_data:/qdrant/storage
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
   app:
     build: .
     depends_on:
       - qdrant
+      - redis
     environment:
       - QDRANT_URL=http://qdrant:6333
+      - CELERY_BROKER_URL=redis://redis:6379/0
     volumes:
       - ./input_data:/app/input_data
     stdin_open: true
     tty: true
     command: ["python", "main.py"]
+  worker:
+    build: .
+    depends_on:
+      - qdrant
+      - redis
+    environment:
+      - QDRANT_URL=http://qdrant:6333
+      - CELERY_BROKER_URL=redis://redis:6379/0
+    command: ["celery", "-A", "async_tasks.tasks", "worker", "--loglevel=info"]
 volumes:
   qdrant_data:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -5,8 +5,8 @@ Check completed items when implemented.
 
 ## Scalable Backend Architecture
 - [✅ ] Containerization: Provide Docker images with Qdrant pre-configured
-- [ ] Kubernetes Support: Helm charts for clustering
-- [ ] Async Processing for heavy ingestion or parsing
+- [x] Kubernetes Support: Helm charts for clustering
+- [x] Async Processing for heavy ingestion or parsing
 
 ## Extensible Modular Design
 - [ ] Pluggable Components for embeddings, language models and vector stores

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: rag-heitaa
+version: 0.1.0
+appVersion: "1.0"
+description: Helm chart for RAG_HEITAA with Qdrant clustering and worker nodes

--- a/helm/templates/app-deployment.yaml
+++ b/helm/templates/app-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rag-heitaa
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: rag-heitaa
+  template:
+    metadata:
+      labels:
+        app: rag-heitaa
+    spec:
+      containers:
+        - name: app
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          env:
+            - name: QDRANT_URL
+              value: http://qdrant:6333
+          command: ["python","main.py"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rag-heitaa
+spec:
+  selector:
+    app: rag-heitaa
+  ports:
+    - port: 80
+      targetPort: 8000

--- a/helm/templates/qdrant-deployment.yaml
+++ b/helm/templates/qdrant-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qdrant
+spec:
+  replicas: {{ .Values.qdrant.replicaCount }}
+  selector:
+    matchLabels:
+      app: qdrant
+  template:
+    metadata:
+      labels:
+        app: qdrant
+    spec:
+      containers:
+        - name: qdrant
+          image: {{ .Values.qdrant.image }}
+          ports:
+            - containerPort: 6333
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qdrant
+spec:
+  selector:
+    app: qdrant
+  ports:
+    - port: 6333
+      targetPort: 6333

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rag-worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      app: rag-worker
+  template:
+    metadata:
+      labels:
+        app: rag-worker
+    spec:
+      containers:
+        - name: worker
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          command: ["celery","-A","async_tasks.tasks","worker","--loglevel=info"]
+          env:
+            - name: QDRANT_URL
+              value: http://qdrant:6333

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+
+image:
+  repository: rag-heitaa
+  tag: latest
+
+qdrant:
+  image: qdrant/qdrant:latest
+  replicaCount: 1
+
+worker:
+  replicaCount: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ numpy==1.26.4
 # Utilities
 python-dotenv==1.0.1
 rich==13.7.1
+celery==5.3.6
+redis==5.0.1
 
 # # Jupyter (optional)
 # ipykernel==6.29.4


### PR DESCRIPTION
## Summary
- add helm chart for clustering (api, qdrant, worker)
- introduce Celery async ingestion with Redis broker
- update Docker compose to include redis and worker
- document Kubernetes and async ingestion
- check off tasks in docs
- add Celery/redis deps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864dc4aca308323925c99b4d8235e36