### PR TITLE
Fix tokenizers build issue on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ source venv/bin/activate  # or venv\Scripts\activate on Windows
 pip install -r requirements.txt
 ```
 
+**Windows note:** The `tokenizers` package may fail to build from source on
+some Rust toolchains. If this happens, install the precompiled wheel with:
+
+```bash
+pip install tokenizers --prefer-binary
+```
+
+The `requirements.txt` file already pins a compatible version
+(`tokenizers==0.13.3`) to avoid these build issues.
+
 ### 3. Set Your API Key
 
 Create a `.env` file in the root folder:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 sentence-transformers==2.2.2
 transformers==4.28.1
 huggingface-hub==0.14.1
+tokenizers==0.13.3           # 🛠 Pin to avoid Rust build issues on Windows
 langchain==0.1.17
 
 


### PR DESCRIPTION
## Summary
- pin `tokenizers==0.13.3` to avoid Rust compilation errors
- document how to install prebuilt wheels for Windows users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651678aae88323adccfad4c8152381