### PR TITLE
Allow Celery broker override via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ helm install rag-heitaa helm
 ```
 
 ### 🚀 Async Ingestion
-Start a Celery worker to process heavy ingestion jobs:
+Start a Celery worker to process heavy ingestion jobs. The broker URL can be
+overridden with the `CELERY_BROKER_URL` environment variable (defaults to
+`redis://redis:6379/0`):
 ```bash
 celery -A async_tasks.tasks worker --loglevel=info
 ```

--- a/async_tasks/tasks.py
+++ b/async_tasks/tasks.py
@@ -1,9 +1,11 @@
 from celery import Celery
+import os
 from embedding.embedder import embed_text
 from parsers.text_parser import parse_txt_folder
 from vector_store.base import index_document, init_collection
 
-app = Celery('rag_tasks', broker='redis://redis:6379/0')
+broker_url = os.getenv("CELERY_BROKER_URL", "redis://redis:6379/0")
+app = Celery('rag_tasks', broker=broker_url)
 
 @app.task
 def ingest_folder(folder_path: str):


### PR DESCRIPTION
## Summary
- let Celery broker URL be configured via `CELERY_BROKER_URL`
- mention environment variable in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865703f4dac8323957be2f6fe7d99f0