### PR TITLE
Fix Docker build with Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.lock ./
 RUN pip install --no-cache-dir -r requirements.lock


### PR DESCRIPTION
## Summary
- upgrade Python base image for Docker to 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686584c5507c8323a995d4636a208912