### PR TITLE
Add static frontend mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,16 @@ Start the FastAPI server with GraphQL and REST endpoints:
 uvicorn api.app:app --reload
 ```
 
-Authenticate requests using the `API_TOKEN` environment variable. Endpoints are
-versioned under `/v1`.
+After starting the server, open `http://localhost:8000/` in your browser to use
+the bundled voice interface. Authenticate requests using the `API_TOKEN`
+environment variable. Endpoints are versioned under `/v1`.
 
 ## 🌐 Voice Frontend
 
-Start the API as shown above and open `frontend/index.html` in a browser.
-Click **Start Speaking** and grant microphone access. Your speech will be transcribed via the Web Speech API, sent to `/v1/chat`, and the response will be displayed and spoken aloud using `speechSynthesis`.
+With the server running, navigate to `http://localhost:8000/` and click
+**Start Speaking**. Grant microphone access and your speech will be transcribed
+via the Web Speech API, sent to `/v1/chat`, and the response will be displayed
+and spoken aloud using `speechSynthesis`.
 ---
 
 ## 🧪 Testing

--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,6 @@
 import os
 from fastapi import Depends, FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
 
@@ -21,6 +22,7 @@ engine = ChatEngine(
 )
 
 app = FastAPI(title="RAG_HEITAA API", version="1.0")
+app.mount("/", StaticFiles(directory="frontend", html=True), name="frontend")
 
 
 def authenticate(creds: HTTPAuthorizationCredentials = Depends(security)):


### PR DESCRIPTION
## Summary
- serve the `frontend` directory from FastAPI using `StaticFiles`
- document how to start the server and visit `http://localhost:8000/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686638fa4c648323b43f4cb64a20fda8