### PR TITLE
Fix README structure and async ingestion note

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ RAG_HEITAA/
 │   └── language_model.py        # GROQ/OpenAI API interface
 ├── vector_store/
 │   └── base.py                  # Qdrant-based vector DB wrapper
+├── api/                         # FastAPI server
+│   └── app.py                   # REST & GraphQL endpoints
+├── frontend/                    # Voice chat UI
+│   └── index.html
+├── async_tasks/                 # Celery tasks
+│   └── tasks.py
 ├── main.py                      # Entry point CLI chatbot
 └── .env                         # API keys for GROQ (not committed)
 ```
@@ -120,6 +126,10 @@ overridden with the `CELERY_BROKER_URL` environment variable (defaults to
 `redis://redis:6379/0`):
 ```bash
 celery -A async_tasks.tasks worker --loglevel=info
+```
+Make sure a Redis instance is accessible at the broker URL, e.g. start one with:
+```bash
+docker run -p 6379:6379 redis
 ```
 
 


### PR DESCRIPTION
## Summary
- expand project structure to include API, frontend and async tasks
- document how to start Redis for async ingestion

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68664f5915b883239d03294b727914ed