### PR TITLE
Expose FastAPI via Docker and enable CORS

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -2,6 +2,7 @@ import os
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from chat_engine.chat_engine import ChatEngine
@@ -23,6 +24,14 @@ engine = ChatEngine(
 )
 
 app = FastAPI(title="RAG_HEITAA API", version="1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Use specific origin in production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.on_event("startup")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     environment:
       - QDRANT_URL=http://qdrant:6333
       - CELERY_BROKER_URL=redis://redis:6379/0
+    ports:
+      - "8000:8000"
     volumes:
       - ./input_data:/app/input_data
     stdin_open: true

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,11 +39,11 @@
       const text = e.results[0][0].transcript;
       transcriptEl.textContent = 'You: ' + text;
       try {
-        const res = await fetch('/v1/chat', {
+        const res = await fetch('http://localhost:8000/v1/chat', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer secret-token'
+            'Authorization': 'Bearer secret-token',
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({ question: text })
         });


### PR DESCRIPTION
## Summary
- expose port 8000 for the FastAPI service
- allow cross-origin requests via `CORSMiddleware`
- update the frontend fetch call to target the API directly
- run unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665bee5e608323a20fc773b50b5899