### PR TITLE
Improve database ingestion and concise responses

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -14,7 +14,9 @@ from vector_store.base import init_collection
 
 security = HTTPBearer()
 
-API_TOKEN = os.getenv("API_TOKEN", "secret-token")
+API_TOKEN = os.getenv("API_TOKEN")
+if not API_TOKEN:
+    raise RuntimeError("API_TOKEN environment variable must be set")
 
 engine = ChatEngine(
     retriever=default_retriever,

--- a/async_tasks/tasks.py
+++ b/async_tasks/tasks.py
@@ -3,6 +3,7 @@ import os
 from embedding.embedder import embed_text
 from parsers.text_parser import parse_txt_folder
 from vector_store.base import index_document, init_collection
+from uuid import uuid4
 
 broker_url = os.getenv("CELERY_BROKER_URL", "redis://redis:6379/0")
 app = Celery('rag_tasks', broker=broker_url)
@@ -12,7 +13,7 @@ def ingest_folder(folder_path: str):
     """Parse text files and index them asynchronously."""
     init_collection()
     docs = parse_txt_folder(folder_path)
-    for idx, doc in enumerate(docs):
+    for doc in docs:
         vector = embed_text(doc["text"])
-        index_document(doc_id=idx, vector=vector, payload={"text": doc["text"], "source": doc["source"]})
+        index_document(doc_id=str(uuid4()), vector=vector, payload={"text": doc["text"], "source": doc["source"]})
     return len(docs)

--- a/chat_engine/chat_engine.py
+++ b/chat_engine/chat_engine.py
@@ -58,6 +58,11 @@ class ChatEngine:
         results = self.retriever(query_vec, top_k=3)
         history = self.session.get_recent_history()
 
+        if not results:
+            warning = "\u26a0\ufe0f I'm unable to locate relevant information."
+            self.session.add_assistant_message(warning)
+            return warning
+
         # Step 3: Assemble context from retrieved documents
         context_snippets = []
         for res in results:

--- a/chat_engine/modules/prompt_assembler.py
+++ b/chat_engine/modules/prompt_assembler.py
@@ -3,7 +3,7 @@ prompt_assembler.py - Builds LLM prompt from query and context
 """
 
 def default_prompt_assembler(user_query, context_text, history):
-    messages = [{"role": "system", "content": "You are a helpful healthcare assistant."}]
+    messages = [{"role": "system", "content": "You are a helpful healthcare assistant. Answer in 2-3 short sentences."}]
     
     # Inject chat history
     messages += history

--- a/language_model/language_model.py
+++ b/language_model/language_model.py
@@ -49,8 +49,9 @@ else:
 class GroqLanguageModel(LanguageModel):
     """Language model wrapper around the Groq API."""
 
-    def __init__(self, model: str = "llama3-8b-8192"):
+    def __init__(self, model: str = "llama3-8b-8192", max_tokens: int = 200):
         self.model = model
+        self.max_tokens = max_tokens
 
     def generate(self, messages: list) -> str:
         try:
@@ -62,7 +63,7 @@ class GroqLanguageModel(LanguageModel):
             body = {
                 "model": self.model,
                 "messages": messages,
-                "max_tokens": 512,
+                "max_tokens": self.max_tokens,
                 "temperature": 0.2,
             }
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from language_model.language_model import generate_answer
 from vector_store.base import init_collection  # ✅ Make sure this is imported!
 from parsers.text_parser import parse_txt_folder  # ✅ Import parser
 from vector_store.base import index_document
+from uuid import uuid4
 
 
 def ingest_input_data():
@@ -13,10 +14,10 @@ def ingest_input_data():
     init_collection()
     print("📚 Parsing and indexing text documents from 'input_data/'...")
     docs = parse_txt_folder("input_data/")  # Customize folder path if needed
-    for idx, doc in enumerate(docs):
+    for doc in docs:
         vector = embed_text(doc["text"])
         index_document(
-            doc_id=idx,
+            doc_id=str(uuid4()),
             vector=vector,
             payload={"text": doc["text"], "source": doc["source"]},
         )

--- a/scripts/ingest_folder.py
+++ b/scripts/ingest_folder.py
@@ -3,15 +3,16 @@ import argparse
 from embedding.embedder import embed_text
 from parsers.text_parser import parse_txt_folder
 from vector_store.base import init_collection, index_document
+from uuid import uuid4
 
 
 def ingest_folder(folder_path: str):
     """Parse text files in ``folder_path`` and index them in the vector store."""
     init_collection()
     docs = parse_txt_folder(folder_path)
-    for idx, doc in enumerate(docs):
+    for doc in docs:
         vector = embed_text(doc["text"])
-        index_document(doc_id=idx, vector=vector,
+        index_document(doc_id=str(uuid4()), vector=vector,
                        payload={"text": doc["text"], "source": doc["source"]})
 
 

--- a/vector_store/base.py
+++ b/vector_store/base.py
@@ -1,14 +1,18 @@
 # vector_store/base.py
 from abc import ABC, abstractmethod
+import logging
+import os
+
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, VectorParams
 from qdrant_client.http.exceptions import UnexpectedResponse
 from qdrant_client.http.models import PointStruct
-import os
 
 COLLECTION_NAME = "claims_collection"
 VECTOR_DIMENSION = 384
 DISTANCE_METRIC = Distance.COSINE
+
+logger = logging.getLogger(__name__)
 
 QDRANT_URL = os.getenv("QDRANT_URL")
 
@@ -17,7 +21,7 @@ def _create_client():
     unreachable or no URL is provided."""
 
     if not QDRANT_URL:
-        # Default to in-memory instance when no URL is specified
+        logger.warning("QDRANT_URL not set, using in-memory instance")
         return QdrantClient(location=":memory:")
 
     try:
@@ -26,8 +30,7 @@ def _create_client():
         client.get_collections()
         return client
     except Exception:
-        # Gracefully fall back to in-memory instance
-        print(f"⚠️ Could not connect to Qdrant at {QDRANT_URL}, using in-memory instance")
+        logger.warning("Could not connect to Qdrant at %s, using in-memory instance", QDRANT_URL)
         return QdrantClient(location=":memory:")
 
 


### PR DESCRIPTION
## Summary
- generate UUIDs when indexing documents to avoid collisions
- require `API_TOKEN` and warn when Qdrant isn't reachable
- shorten LM responses and give instructions to be concise
- warn user if no documents are found

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867886203788323ba4d3d49ff39441f