### PR TITLE
Improve dependency fallbacks

### DIFF
--- a/language_model/language_model.py
+++ b/language_model/language_model.py
@@ -1,8 +1,15 @@
 # language_model/lm.py
 import os
 import logging
-from dotenv import load_dotenv
-import requests
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        return False
+try:
+    import requests
+except ImportError:  # pragma: no cover - optional dependency
+    requests = None
 from .base import LanguageModel
 
 logger = logging.getLogger(__name__)
@@ -54,6 +61,8 @@ class GroqLanguageModel(LanguageModel):
         self.max_tokens = max_tokens
 
     def generate(self, messages: list) -> str:
+        if requests is None:
+            raise RuntimeError("requests package is required for Groq API calls")
         try:
             url = "https://api.groq.com/openai/v1/chat/completions"
             headers = {

--- a/parsers/text_parser.py
+++ b/parsers/text_parser.py
@@ -1,24 +1,38 @@
 import os
 from typing import List, Dict
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+try:
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
+except ImportError:  # pragma: no cover - optional dependency
+    RecursiveCharacterTextSplitter = None
 
 def parse_txt_folder(folder_path: str, chunk_size: int = 500, chunk_overlap: int = 100) -> List[Dict]:
     """
     Parse .txt files in a folder and split into chunks using LangChain's RecursiveCharacterTextSplitter.
     Returns list of dicts: {"text": chunk, "source": filename}
     """
-    splitter = RecursiveCharacterTextSplitter(
-        chunk_size=chunk_size,
-        chunk_overlap=chunk_overlap,
-        separators=["\n\n", "\n", ".", " ", ""]
-    )
+    if RecursiveCharacterTextSplitter is None:
+        def _split(text):
+            chunks = []
+            for i in range(0, len(text), chunk_size):
+                chunks.append(text[i : i + chunk_size])
+            return chunks
+        splitter = None
+    else:
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            separators=["\n\n", "\n", ".", " ", ""]
+        )
 
     documents = []
     for filename in os.listdir(folder_path):
         if filename.endswith(".txt"):
             with open(os.path.join(folder_path, filename), "r", encoding="utf-8") as f:
                 text = f.read()
-                chunks = splitter.split_text(text)
+                if splitter is None:
+                    chunks = _split(text)
+                else:
+                    chunks = splitter.split_text(text)
                 for chunk in chunks:
                     documents.append({
                         "text": chunk.strip(),

--- a/vector_store/base.py
+++ b/vector_store/base.py
@@ -3,22 +3,32 @@ from abc import ABC, abstractmethod
 import logging
 import os
 
-from qdrant_client import QdrantClient
-from qdrant_client.models import Distance, VectorParams
-from qdrant_client.http.exceptions import UnexpectedResponse
-from qdrant_client.http.models import PointStruct
+try:
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import Distance, VectorParams
+    from qdrant_client.http.exceptions import UnexpectedResponse
+    from qdrant_client.http.models import PointStruct
+except ImportError:  # pragma: no cover - optional dependency
+    QdrantClient = None
+    Distance = None
+    VectorParams = None
+    UnexpectedResponse = Exception
+    PointStruct = None
 
 COLLECTION_NAME = "claims_collection"
 VECTOR_DIMENSION = 384
-DISTANCE_METRIC = Distance.COSINE
+DISTANCE_METRIC = Distance.COSINE if Distance else None
 
 logger = logging.getLogger(__name__)
 
 QDRANT_URL = os.getenv("QDRANT_URL")
 
 def _create_client():
-    """Create a Qdrant client. Fall back to in-memory instance if the server is
-    unreachable or no URL is provided."""
+    """Create a Qdrant client if available and reachable."""
+
+    if QdrantClient is None:
+        logger.warning("qdrant_client not installed; falling back to in-memory store")
+        return None
 
     if not QDRANT_URL:
         logger.warning("QDRANT_URL not set, using in-memory instance")
@@ -85,8 +95,54 @@ class QdrantVectorStore(VectorStore):
             raise RuntimeError(f"Query failed: {e}")
 
 
+class InMemoryVectorStore(VectorStore):
+    """Simple in-memory fallback when qdrant_client is unavailable."""
+
+    def __init__(self):
+        self._data = []  # List of (id, vector, payload)
+
+    def init_collection(self):
+        pass  # Nothing to initialize
+
+    def index_document(self, doc_id, vector, payload):
+        self._data.append((doc_id, vector, payload))
+
+    def _similarity(self, v1, v2):
+        try:
+            import numpy as np
+        except ImportError:  # pragma: no cover - optional dependency
+            np = None
+
+        if np is not None:
+            v1 = np.array(v1)
+            v2 = np.array(v2)
+            denom = (np.linalg.norm(v1) * np.linalg.norm(v2)) or 1.0
+            return float(np.dot(v1, v2) / denom)
+        # Basic Python fallback (cosine similarity)
+        import math
+
+        dot = sum(a * b for a, b in zip(v1, v2))
+        norm1 = math.sqrt(sum(a * a for a in v1))
+        norm2 = math.sqrt(sum(b * b for b in v2))
+        denom = (norm1 * norm2) or 1.0
+        return float(dot / denom)
+
+    def query_vector(self, vector, top_k: int = 5, filters=None):
+        scored = [
+            (self._similarity(vector, v), payload)
+            for _, v, payload in self._data
+        ]
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        class DummyResult:
+            def __init__(self, payload):
+                self.payload = payload
+
+        return [DummyResult(p) for _, p in scored[:top_k]]
+
+
 # Instantiate a default store for convenience
-_default_store = QdrantVectorStore()
+_default_store = QdrantVectorStore() if QdrantClient else InMemoryVectorStore()
 
 def init_collection():
     _default_store.init_collection()


### PR DESCRIPTION
## Summary
- add optional imports for qdrant-client, sentence-transformers, dotenv, requests and langchain
- implement InMemoryVectorStore when qdrant-client isn't available
- fall back to deterministic embeddings and simple text splitting without numpy or langchain
- adjust GroqLanguageModel to check for requests

## Testing
- `pytest -q`
- `python main.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68681db0f9008323a64f2326b088b36c