### PR TITLE
Add Fernet encryption utilities

### DIFF
--- a/cybersecurity/encryption.py
+++ b/cybersecurity/encryption.py
@@ -1,0 +1,52 @@
+"""Simple symmetric encryption helpers using Fernet."""
+
+from __future__ import annotations
+
+import os
+
+try:
+    from cryptography.fernet import Fernet
+except ImportError:  # pragma: no cover - optional dependency
+    Fernet = None
+
+
+ENV_KEY = "ENCRYPTION_KEY"
+
+
+def generate_key() -> bytes:
+    """Generate and store a new Fernet key in the environment."""
+    if Fernet is None:
+        raise RuntimeError("cryptography is required for encryption")
+    key = Fernet.generate_key()
+    os.environ[ENV_KEY] = key.decode()
+    return key
+
+
+def _get_fernet() -> Fernet:
+    if Fernet is None:
+        raise RuntimeError("cryptography is required for encryption")
+    key = os.getenv(ENV_KEY)
+    if not key:
+        raise ValueError(f"{ENV_KEY} not set. Call generate_key() first.")
+    return Fernet(key.encode())
+
+
+def encrypt_data(data: str | bytes) -> str:
+    """Encrypt the provided data and return a token string."""
+    f = _get_fernet()
+    if isinstance(data, str):
+        data = data.encode()
+    token = f.encrypt(data)
+    return token.decode()
+
+
+def decrypt_data(token: str | bytes) -> str:
+    """Decrypt the token using the stored key and return plaintext."""
+    f = _get_fernet()
+    if isinstance(token, str):
+        token = token.encode()
+    plaintext = f.decrypt(token)
+    try:
+        return plaintext.decode()
+    except UnicodeDecodeError:
+        return plaintext

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ python-dotenv==1.0.1
 rich==13.7.1
 celery==5.3.6
 redis==5.0.1
+cryptography==42.0.5
 
 # API server
 fastapi==0.97.0

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from cybersecurity import encryption  # noqa: E402
+
+
+def test_encrypt_decrypt_roundtrip(monkeypatch):
+    monkeypatch.delenv(encryption.ENV_KEY, raising=False)
+    key = encryption.generate_key()
+    assert os.environ[encryption.ENV_KEY] == key.decode()
+
+    token = encryption.encrypt_data("hello")
+    assert token != "hello"
+    plaintext = encryption.decrypt_data(token)
+    assert plaintext == "hello"


### PR DESCRIPTION
## Summary
- add simple encryption helpers using `cryptography.fernet`
- include new test for round-trip encryption
- require `cryptography` in dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f25d22c08323a0413ec9d98890b0