### PR TITLE
Add integrity hashing and audit log support

### DIFF
--- a/cybersecurity/integrity.py
+++ b/cybersecurity/integrity.py
@@ -1,0 +1,15 @@
+"""Data integrity utilities using SHA-256."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def generate_hash(data: bytes) -> str:
+    """Return the SHA-256 hex digest of ``data``."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def verify_hash(data: bytes, expected_hash: str) -> bool:
+    """Check that ``data`` matches the given SHA-256 ``expected_hash``."""
+    return generate_hash(data) == expected_hash.lower()

--- a/storage/audit_log.py
+++ b/storage/audit_log.py
@@ -6,15 +6,38 @@ import json
 import os
 from datetime import datetime
 
+from cybersecurity.integrity import generate_hash
+
 AUDIT_LOG = os.getenv("AUDIT_LOG", "audit.log")
 
 
-def log_audit_event(event_type: str, details: dict) -> None:
-    """Append an audit entry to the log file."""
+def log_audit_event(
+    event_type: str,
+    details: dict,
+    data: bytes | None = None,
+    include_hash: bool = False,
+) -> None:
+    """Append an audit entry to the log file.
+
+    When ``include_hash`` is ``True`` and ``data`` is provided, a SHA-256 hash
+    of the data will be stored alongside the event details.
+    """
     entry = {
         "timestamp": datetime.utcnow().isoformat() + "Z",
         "event": event_type,
         "details": details,
     }
+    if include_hash and data is not None:
+        entry["hash"] = generate_hash(data)
     with open(AUDIT_LOG, "a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
+
+
+def log_data_stored(data: bytes, include_hash: bool = False) -> None:
+    """Log a ``data_stored`` event, optionally including a data hash."""
+    log_audit_event("data_stored", {}, data=data, include_hash=include_hash)
+
+
+def log_data_retrieved(data: bytes, include_hash: bool = False) -> None:
+    """Log a ``data_retrieved`` event, optionally including a data hash."""
+    log_audit_event("data_retrieved", {}, data=data, include_hash=include_hash)

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,23 @@
+import json
+import os
+import sys
+
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from storage import audit_log  # noqa: E402
+from cybersecurity import integrity  # noqa: E402
+
+
+def test_log_data_stored_with_hash(monkeypatch, tmp_path):
+    log_file = tmp_path / "audit.log"
+    monkeypatch.setenv("AUDIT_LOG", str(log_file))
+    monkeypatch.setattr(audit_log, "AUDIT_LOG", str(log_file), raising=False)
+
+    audit_log.log_data_stored(b"hello", include_hash=True)
+
+    entry = json.loads(log_file.read_text().splitlines()[0])
+    assert entry["event"] == "data_stored"
+    expected = integrity.generate_hash(b"hello")
+    assert entry["hash"] == expected

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from cybersecurity import integrity  # noqa: E402
+
+
+def test_hash_generation_and_verification():
+    data = b"secret"
+    digest = integrity.generate_hash(data)
+    assert isinstance(digest, str)
+    assert integrity.verify_hash(data, digest)
+    assert not integrity.verify_hash(b"other", digest)


### PR DESCRIPTION
## Summary
- add SHA-256 hashing helpers in `cybersecurity/integrity.py`
- expand `storage/audit_log.py` with optional hash logging
- add tests for new hashing utilities and audit log behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f3c4cbb08323aa36f254b7d47906