### PR TITLE
Add SecurityAgent for encrypted message workflows

### DIFF
--- a/agents/security_agent.py
+++ b/agents/security_agent.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from .base import Agent
+from cybersecurity import encryption, integrity, monitor
+
+
+class SecurityAgent(Agent):
+    """Agent that validates message integrity and service health."""
+
+    def act(self, message: str, context: dict) -> tuple[str, dict]:
+        """Decrypt the message, verify its hash and re-encrypt the result."""
+        # Attempt to decrypt the incoming message
+        try:
+            plaintext = encryption.decrypt_data(message)
+            context["decrypted"] = True
+        except Exception:
+            plaintext = message
+            context["decrypted"] = False
+
+        # Verify hash when provided
+        expected = context.get("hash")
+        if expected is not None:
+            context["hash_valid"] = integrity.verify_hash(plaintext.encode(), expected)
+
+        # Confirm services are healthy
+        monitor.check_services()
+        context["services_checked"] = True
+
+        # Re-encrypt outgoing message
+        try:
+            encrypted = encryption.encrypt_data(plaintext)
+            context["encrypted"] = True
+        except Exception:
+            encrypted = plaintext
+            context["encrypted"] = False
+
+        return encrypted, context

--- a/tests/test_security_agent.py
+++ b/tests/test_security_agent.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from agents.security_agent import SecurityAgent  # noqa: E402
+from cybersecurity import encryption, integrity, monitor  # noqa: E402
+
+
+def test_security_agent_cycle(monkeypatch):
+    # Setup encryption key
+    monkeypatch.delenv(encryption.ENV_KEY, raising=False)
+    encryption.generate_key()
+
+    plaintext = "secure"
+    token = encryption.encrypt_data(plaintext)
+    expected = integrity.generate_hash(plaintext.encode())
+
+    called = {}
+    monkeypatch.setattr(monitor, "check_services", lambda: called.setdefault("called", True))
+
+    agent = SecurityAgent()
+    out, ctx = agent.act(token, {"hash": expected})
+
+    assert ctx["decrypted"] is True
+    assert ctx["hash_valid"] is True
+    assert ctx["encrypted"] is True
+    assert ctx["services_checked"] is True
+    assert called.get("called") is True
+
+    assert encryption.decrypt_data(out) == plaintext


### PR DESCRIPTION
## Summary
- add `agents/security_agent.py` for decrypting incoming messages, verifying data integrity, checking service health, and re-encrypting responses
- test new security agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f6041b388323b8a00c3662715728