### PR TITLE
Add tests for SecurityAgent

### DIFF
--- a/tests/test_security_agent.py
+++ b/tests/test_security_agent.py
@@ -9,25 +9,56 @@ from agents.security_agent import SecurityAgent  # noqa: E402
 from cybersecurity import encryption, integrity, monitor  # noqa: E402
 
 
-def test_security_agent_cycle(monkeypatch):
-    # Setup encryption key
+def _setup_key(monkeypatch):
+    """Utility to reset and generate an encryption key."""
     monkeypatch.delenv(encryption.ENV_KEY, raising=False)
     encryption.generate_key()
 
-    plaintext = "secure"
+
+def test_encrypt_decrypt_cycle(monkeypatch):
+    _setup_key(monkeypatch)
+    plaintext = "secret"
     token = encryption.encrypt_data(plaintext)
-    expected = integrity.generate_hash(plaintext.encode())
 
     called = {}
     monkeypatch.setattr(monitor, "check_services", lambda: called.setdefault("called", True))
 
     agent = SecurityAgent()
-    out, ctx = agent.act(token, {"hash": expected})
+    out, ctx = agent.act(token, {})
 
     assert ctx["decrypted"] is True
-    assert ctx["hash_valid"] is True
     assert ctx["encrypted"] is True
     assert ctx["services_checked"] is True
+    assert "hash_valid" not in ctx
     assert called.get("called") is True
-
     assert encryption.decrypt_data(out) == plaintext
+
+
+def test_hash_verification(monkeypatch):
+    _setup_key(monkeypatch)
+    plaintext = "verify"
+    token = encryption.encrypt_data(plaintext)
+    expected = integrity.generate_hash(plaintext.encode())
+
+    monkeypatch.setattr(monitor, "check_services", lambda: None)
+
+    agent = SecurityAgent()
+    out, ctx = agent.act(token, {"hash": expected})
+
+    assert ctx["hash_valid"] is True
+    assert encryption.decrypt_data(out) == plaintext
+
+    wrong = integrity.generate_hash(b"bad")
+    out2, ctx2 = agent.act(token, {"hash": wrong})
+    assert ctx2["hash_valid"] is False
+    assert encryption.decrypt_data(out2) == plaintext
+
+
+def test_service_health_called(monkeypatch):
+    _setup_key(monkeypatch)
+    monkeypatch.setattr(monitor, "check_services", lambda: setattr(monitor, "_called", True))
+
+    agent = SecurityAgent()
+    agent.act("hello", {})
+
+    assert getattr(monitor, "_called", False)


### PR DESCRIPTION
## Summary
- extend `tests/test_security_agent.py` with encryption roundtrip, hash checks, and service monitoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f8abf3b88323b2f4d9bffea10d3c