### PR TITLE
Add timeout to Groq API call

### DIFF
--- a/language_model/language_model.py
+++ b/language_model/language_model.py
@@ -76,7 +76,7 @@ class GroqLanguageModel(LanguageModel):
                 "temperature": 0.2,
             }
 
-            response = requests.post(url, headers=headers, json=body)
+            response = requests.post(url, headers=headers, json=body, timeout=10)
             response.raise_for_status()
             result = response.json()
             answer = result["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary
- add a 10 second timeout on HTTP requests to Groq API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abdf804088323838d6c93d8a8cd25