### PR TITLE
Handle optional gTTS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ pip install tokenizers --prefer-binary
 The `requirements.txt` file already pins a compatible version
 (`tokenizers==0.13.3`) to avoid these build issues.
 
+The `gTTS` package is also required for the optional text-to-speech feature. It
+is included in `requirements.txt` and can be installed along with the other
+dependencies.
+
 If the SentenceTransformer model cannot be downloaded (e.g. when running
 offline), the application will fall back to deterministic random embeddings so
 that you can still test the pipeline.

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,4 +43,6 @@ graphene==3.3
 # SpaCy model (run separately after install)
 # python -m spacy download en_core_web_sm
 streamlit==1.33.0
+
+# Text-to-speech
 gTTS==2.5.4

--- a/utils/text_to_speech.py
+++ b/utils/text_to_speech.py
@@ -1,7 +1,12 @@
 import base64
 import io
 
-from gtts import gTTS
+try:
+    from gtts import gTTS
+except Exception as exc:  # pragma: no cover - import-time
+    raise ImportError(
+        "gtts package is required for text-to-speech. Install it via `pip install gTTS`."
+    ) from exc
 
 
 def text_to_speech_base64(text: str, lang: str = "en") -> str:


### PR DESCRIPTION
## Summary
- safeguard text-to-speech import with fallback error message
- note gTTS usage in `README`
- add comment for gTTS requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abf42f3c0832392e78a71eca1397b