### PR TITLE
Use chat messages for RAG answer generation

### DIFF
--- a/question_answering/rag_implementation.py
+++ b/question_answering/rag_implementation.py
@@ -16,9 +16,19 @@ def answer_query(user_query: str) -> str:
         if res.payload and "text" in res.payload:
             context_snippets.append(res.payload["text"])
     context_text = "\n\n".join(context_snippets)
-    # 4. Create a prompt for the LLM that includes the context
-    prompt = (f"You are a healthcare claims assistant. Use the following claim records as context to answer the question.\n"
-              f"Context:\n{context_text}\n\nQuestion: {user_query}\nAnswer:")
-    # 5. Generate answer using OpenAI model
-    answer = generate_answer(prompt)
+    # 4. Build a chat-style message list for the language model
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a healthcare claims assistant. "
+                "Use the following claim records as context to answer the question."
+            ),
+        },
+        {"role": "system", "content": f"Context:\n{context_text}"},
+        {"role": "user", "content": user_query},
+    ]
+
+    # 5. Generate answer using the language model
+    answer = generate_answer(messages)
     return answer

--- a/tests/test_rag_implementation.py
+++ b/tests/test_rag_implementation.py
@@ -1,0 +1,47 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_modules(monkeypatch):
+    """Stub heavy dependencies for rag_implementation tests."""
+    import os
+    project_root = os.path.dirname(os.path.dirname(__file__))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+    embedding = types.ModuleType("embedding")
+    embedder = types.ModuleType("embedding.embedder")
+    embedder.embed_text = lambda text: [0.1, 0.2]
+    embedding.embedder = embedder
+    monkeypatch.setitem(sys.modules, "embedding", embedding)
+    monkeypatch.setitem(sys.modules, "embedding.embedder", embedder)
+
+    vector_store = types.ModuleType("vector_store")
+    base = types.ModuleType("vector_store.base")
+    class DummyResult:
+        def __init__(self, payload):
+            self.payload = payload
+    base.DummyResult = DummyResult
+    base.query_vector = lambda vec, top_k=5, filters=None: [DummyResult({"text": "ctx"})]
+    vector_store.base = base
+    monkeypatch.setitem(sys.modules, "vector_store", vector_store)
+    monkeypatch.setitem(sys.modules, "vector_store.base", base)
+
+    language_model = types.ModuleType("language_model")
+    lm_mod = types.ModuleType("language_model.language_model")
+    lm_mod.generate_answer = lambda messages: "assistant response"
+    language_model.language_model = lm_mod
+    monkeypatch.setitem(sys.modules, "language_model", language_model)
+    monkeypatch.setitem(sys.modules, "language_model.language_model", lm_mod)
+
+    yield
+
+
+def test_answer_query_returns_llm_output():
+    mod = importlib.import_module("question_answering.rag_implementation")
+    result = mod.answer_query("hello")
+    assert result == "assistant response"


### PR DESCRIPTION
## Summary
- refactor RAG answer_query to pass chat messages to `generate_answer`
- add regression test for `answer_query`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac033704c8323b47b6ab364f6ca3b