### PR TITLE
Gracefully handle missing spaCy model

### DIFF
--- a/storage/deidentifier.py
+++ b/storage/deidentifier.py
@@ -1,15 +1,28 @@
 # text_cleaning/deid.py
-import spacy
 from utils.logger import log
 
-# Load spaCy model for NER (using a general English model; could use a clinical NER model if available)
-nlp = spacy.load("en_core_web_sm")
+try:
+    import spacy
+    try:
+        # Load spaCy model for NER (using a general English model; could use a clinical NER model if available)
+        nlp = spacy.load("en_core_web_sm")
+    except OSError:  # model not found
+        log("Warning: spaCy model 'en_core_web_sm' not found. PHI will not be removed.")
+        nlp = None
+except ModuleNotFoundError:  # spaCy not installed at all
+    log("Warning: spaCy is not installed. PHI will not be removed.")
+    nlp = None
 
 # Define which entity labels to redact (PHI categories)
 PHI_LABELS = {"PERSON", "ORG", "GPE", "LOC", "FAC", "DATE"}  # Names, Orgs, Geographical, Facilities, Dates, etc.
 
 def deidentify_text(text: str) -> str:
     """Remove or mask PHI entities from the input text."""
+    if nlp is None:
+        # spaCy unavailable, just return original text
+        log("deidentifier unavailable - returning input text")
+        return text
+
     doc = nlp(text)
     cleaned_text = text
     # Optional feedback via logging


### PR DESCRIPTION
## Summary
- handle missing spaCy install or model in the deidentifier
- return the original text when spaCy isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac48318e88323a484f4f4a2fc511e