### PR TITLE
Add NLPAgent and selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,15 @@ python scripts/ingest_folder.py path/to/folder
 from agents.deid_agent import DeidAgent
 from agents.summary_agent import SummaryAgent
 from agents.rag_agent import RAGAgent
+from agents.nlp_agent import NLPAgent
 from core.multi_agent import MultiAgentCoordinator
 
-coordinator = MultiAgentCoordinator([DeidAgent(), SummaryAgent(), RAGAgent()])
+coordinator = MultiAgentCoordinator([
+    DeidAgent(),
+    SummaryAgent(),
+    NLPAgent(),
+    RAGAgent(),
+])
 response = coordinator.run("Patient John Doe was admitted yesterday.")
 ```
 
@@ -308,7 +314,8 @@ streamlit run frontend/chat_ui.py
 ```
 
 Type your question in the input box and the assistant's answer will appear
-below. Each interaction is shown so you can review the conversation history.
+below. Use the dropdown to switch between the RAG agent and the NLP agent.
+Each interaction is shown so you can review the conversation history.
 ---
 
 ## 🧪 Testing

--- a/agents/nlp_agent.py
+++ b/agents/nlp_agent.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from gensim.models import Word2Vec
+import numpy as np
+
+from .base import Agent
+
+
+class NLPAgent(Agent):
+    """Agent that extracts simple NLP features from the message."""
+
+    def __init__(self, corpus: list[str] | None = None):
+        # Small default corpus for vectorizer and Word2Vec
+        self.corpus = corpus or [
+            "Simplilearn offers courses in AI and is also located in the US",
+            "AI is becoming part of everyday life and AI is super important",
+            "Simplilearn and AI are integral part of everyday life",
+        ]
+        self.vectorizer = TfidfVectorizer()
+        self.vectorizer.fit(self.corpus)
+
+        tokenized = [sent.lower().split() for sent in self.corpus]
+        self.w2v = Word2Vec(sentences=tokenized, vector_size=50, window=5, min_count=1, sg=0)
+
+    def act(self, message: str, context: dict) -> tuple[str, dict]:
+        # Compute top keywords with TF-IDF
+        tfidf = self.vectorizer.transform([message]).toarray()[0]
+        feats = self.vectorizer.get_feature_names_out()
+        if tfidf.size:
+            top_idx = np.argsort(tfidf)[::-1][:3]
+            keywords = [feats[i] for i in top_idx if tfidf[i] > 0]
+        else:
+            keywords = []
+        context["keywords"] = keywords
+
+        # Average Word2Vec embedding for known words
+        tokens = [t for t in message.lower().split() if t in self.w2v.wv]
+        if tokens:
+            vec = np.mean([self.w2v.wv[t] for t in tokens], axis=0)
+            preview = np.array2string(vec[:5], precision=3, separator=", ")
+        else:
+            preview = "no known words"
+        response = f"Keywords: {', '.join(keywords)} | w2v[:5]: {preview}"
+        return response, context

--- a/frontend/chat_ui.py
+++ b/frontend/chat_ui.py
@@ -5,6 +5,7 @@ from chat_engine.modules.prompt_assembler import default_prompt_assembler
 from embedding.embedder import embed_text
 from language_model.language_model import generate_answer
 from vector_store.base import init_collection
+from agents.nlp_agent import NLPAgent
 
 st.set_page_config(page_title="RAG_HEITAA Chat", page_icon="🩺")
 
@@ -17,14 +18,24 @@ if "engine" not in st.session_state:
         llm=generate_answer,
         prompt_assembler=default_prompt_assembler,
     )
+    st.session_state.nlp_agent = NLPAgent()
     st.session_state.history = []
 
 st.title("RAG_HEITAA Health Assistant")
 
+agent_choice = st.selectbox(
+    "Choose agent",
+    ["RAG", "NLP"],
+)
+
 user_input = st.text_input("Ask a question about your claim:", key="input")
 if st.button("Send") and user_input:
-    engine = st.session_state.engine
-    answer = engine.answer_query(user_input)
+    if agent_choice == "RAG":
+        engine = st.session_state.engine
+        answer = engine.answer_query(user_input)
+    else:
+        agent = st.session_state.nlp_agent
+        answer, _ = agent.act(user_input, {})
     st.session_state.history.append((user_input, answer))
 
 for i, (q, a) in enumerate(reversed(st.session_state.history)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ langchain==0.1.17
 # Text processing & NLP
 spacy==3.7.4
 nltk==3.8.1
+scikit-learn==1.7.0
+gensim==4.3.3
 
 # Vector DB & backend
 qdrant-client==1.7.0

--- a/tests/test_nlp_agent.py
+++ b/tests/test_nlp_agent.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from agents.nlp_agent import NLPAgent  # noqa: E402
+
+
+def test_nlp_agent_keywords():
+    agent = NLPAgent(["this is a test corpus"])
+    msg = "this test"
+    out, ctx = agent.act(msg, {})
+    assert "Keywords" in out
+    assert ctx["keywords"]


### PR DESCRIPTION
## Summary
- implement `NLPAgent` with TF‑IDF keywords and Word2Vec preview
- expose the agent in the Streamlit UI with a dropdown
- document the new agent and UI usage in README
- add gensim and scikit-learn to requirements
- test NLPAgent functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aca05f73c832394049884422b4d0b