### PR TITLE
Improve LLMSupervisor for dynamic agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,28 @@ response = coordinator.run("Patient John Doe was admitted yesterday.")
 Each agent receives the current message and can store results in the shared
 `context` for the next agent.
 
+For more dynamic control you can use ``LLMSupervisor`` which relies on a
+language model to pick the next agent based on the conversation so far.
+It automatically discovers agents from the ``agents`` package and lets you
+register new ones programmatically:
+
+```python
+from core import LLMSupervisor
+
+supervisor = LLMSupervisor.from_package()
+reply = supervisor.run("Summarize and anonymize this report")
+```
+
+If you need a smarter orchestrator that can summarize long histories and
+prevent runaway loops, use ``AdvancedSupervisor``:
+
+```python
+from core import AdvancedSupervisor
+
+supervisor = AdvancedSupervisor.from_package(max_turns=5)
+result = supervisor.run("Encrypt then summarize this document")
+```
+
 ### Workflow Hooks & Events
 
 Workflows can trigger custom hooks before and after each agent runs. Subscribe

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,12 @@
-# Core package
+"""Core orchestration utilities."""
+
+from .workflow import Workflow
+from .multi_agent import MultiAgentCoordinator
+from .supervisor import LLMSupervisor, AdvancedSupervisor
+
+__all__ = [
+    "Workflow",
+    "MultiAgentCoordinator",
+    "LLMSupervisor",
+    "AdvancedSupervisor",
+]

--- a/core/supervisor.py
+++ b/core/supervisor.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from agents.summary_agent import SummaryAgent
+import importlib
+import pkgutil
+
+from agents.base import Agent
+from utils.logger import log
+from utils.event_bus import event_bus
+from utils.metrics import AGENT_RUNS, WORKFLOW_SECONDS
+from language_model.language_model import generate_answer
+
+
+def discover_agents(package: str = "agents") -> Dict[str, Agent]:
+    """Import all Agent subclasses from the given package."""
+    pkg = importlib.import_module(package)
+    discovered: Dict[str, Agent] = {}
+    for mod_info in pkgutil.iter_modules(pkg.__path__):
+        module = importlib.import_module(f"{package}.{mod_info.name}")
+        for name, obj in vars(module).items():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, Agent)
+                and obj is not Agent
+            ):
+                try:
+                    discovered[name] = obj()
+                except Exception:
+                    log(f"Failed to instantiate agent {name}")
+    return discovered
+
+
+class LLMSupervisor:
+    """Coordinate agents using an LLM to dynamically choose the next step."""
+
+    def __init__(self, agents: Dict[str, Agent] | None = None, system_prompt: str | None = None):
+        agents = agents or discover_agents()
+        if not agents:
+            raise ValueError("At least one agent must be provided")
+        self.agents = agents
+        self.context: Dict = {"messages": []}
+        self.system_prompt = system_prompt or self._default_prompt()
+
+    @classmethod
+    def from_package(cls, package: str = "agents", **kwargs) -> "LLMSupervisor":
+        """Create a supervisor loading all agents from ``package``."""
+        return cls(discover_agents(package), **kwargs)
+
+    def register_agent(self, name: str, agent: Agent) -> None:
+        """Add or replace an agent used by the supervisor."""
+        self.agents[name] = agent
+
+    def unregister_agent(self, name: str) -> None:
+        """Remove an agent by name if present."""
+        self.agents.pop(name, None)
+
+    def available_agents(self) -> List[str]:
+        """Return the list of currently registered agent names."""
+        return list(self.agents.keys())
+
+    def _default_prompt(self) -> str:
+        return (
+            "You are a supervisor that manages the following agents: "
+            + ", ".join(self.agents.keys())
+            + ". After each response decide which agent should act next or reply FINISH."
+        )
+
+    def _route(self) -> str:
+        """Ask the language model which agent should run next."""
+        options = list(self.agents.keys()) + ["FINISH"]
+        messages: List[dict] = (
+            [{"role": "system", "content": self.system_prompt}]
+            + self.context["messages"]
+            + [
+                {
+                    "role": "system",
+                    "content": f"Who should act next? Options: {options}",
+                }
+            ]
+        )
+        response = generate_answer(messages)
+        choice = response.strip()
+        if choice not in options:
+            choice = "FINISH"
+        return choice
+
+    def run(self, message: str) -> str:
+        cid = log(f"Starting LLMSupervisor run with input: {message}")
+        self.context["messages"].append({"role": "user", "content": message})
+
+        if WORKFLOW_SECONDS:
+            timer = WORKFLOW_SECONDS.time()
+        else:
+            timer = None
+
+        event_bus.emit("workflow_start", message=message)
+
+        msg = message
+        next_agent = self._route()
+        while next_agent != "FINISH":
+            agent = self.agents.get(next_agent)
+            if agent is None:
+                break
+            event_bus.emit("agent_start", agent=next_agent)
+            msg, self.context = agent.act(msg, self.context)
+            self.context["messages"].append({"role": "assistant", "content": msg})
+            if AGENT_RUNS:
+                AGENT_RUNS.labels(agent=next_agent).inc()
+            event_bus.emit("agent_end", agent=next_agent, message=msg)
+            log(f"{next_agent} produced: {msg}", cid)
+            next_agent = self._route()
+
+        event_bus.emit(
+            "workflow_end", message=msg, context=self.context
+        )
+        if timer:
+            timer.observe_duration()
+        return msg
+
+
+class AdvancedSupervisor(LLMSupervisor):
+    """Enhanced supervisor with summarization and turn limits."""
+
+    def __init__(
+        self,
+        agents: Dict[str, Agent] | None = None,
+        system_prompt: str | None = None,
+        *,
+        max_turns: int = 10,
+        max_history: int = 6,
+        summarizer: Agent | None = None,
+    ):
+        super().__init__(agents, system_prompt)
+        self.max_turns = max_turns
+        self.max_history = max_history
+        self.summarizer = summarizer or SummaryAgent()
+
+    def _maybe_summarize(self) -> None:
+        messages = self.context.get("messages", [])
+        if len(messages) > self.max_history:
+            text = "\n".join(m["content"] for m in messages)
+            summary, _ = self.summarizer.act(text, {})
+            self.context["messages"] = [{"role": "system", "content": summary}]
+
+    def run(self, message: str) -> str:
+        cid = log(f"Starting AdvancedSupervisor run with input: {message}")
+        self.context.setdefault("messages", []).append({"role": "user", "content": message})
+
+        if WORKFLOW_SECONDS:
+            timer = WORKFLOW_SECONDS.time()
+        else:
+            timer = None
+
+        event_bus.emit("workflow_start", message=message)
+
+        msg = message
+        next_agent = self._route()
+        turns = 0
+        while next_agent != "FINISH" and turns < self.max_turns:
+            agent = self.agents.get(next_agent)
+            if agent is None:
+                break
+            event_bus.emit("agent_start", agent=next_agent)
+            try:
+                msg, self.context = agent.act(msg, self.context)
+            except Exception as exc:  # pragma: no cover - defensive
+                log(f"Agent {next_agent} failed: {exc}", cid)
+                break
+            self.context["messages"].append({"role": "assistant", "content": msg})
+            if AGENT_RUNS:
+                AGENT_RUNS.labels(agent=next_agent).inc()
+            event_bus.emit("agent_end", agent=next_agent, message=msg)
+            log(f"{next_agent} produced: {msg}", cid)
+            self._maybe_summarize()
+            next_agent = self._route()
+            turns += 1
+
+        if turns >= self.max_turns:
+            log("Max turns reached", cid)
+
+        event_bus.emit("workflow_end", message=msg, context=self.context)
+        if timer:
+            timer.observe_duration()
+        return msg

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import types
+import pkgutil
+
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from agents.base import Agent  # noqa: E402
+
+
+class AgentA(Agent):
+    def act(self, message: str, context: dict):
+        context.setdefault("order", []).append("A")
+        return message + "a", context
+
+
+class AgentB(Agent):
+    def act(self, message: str, context: dict):
+        context.setdefault("order", []).append("B")
+        return message + "b", context
+
+
+# Stub generate_answer to control routing decisions
+responses = iter(["AgentA", "AgentB", "FINISH"])
+
+
+def fake_generate_answer(messages):
+    return next(responses)
+
+
+import importlib
+import language_model.language_model as lm_mod  # type: ignore
+lm_mod.generate_answer = fake_generate_answer
+
+import core.supervisor as sup_mod  # noqa: E402
+importlib.reload(sup_mod)
+LLMSupervisor = sup_mod.LLMSupervisor
+AdvancedSupervisor = sup_mod.AdvancedSupervisor
+discover_agents = sup_mod.discover_agents
+
+
+def test_llm_supervisor_runs_agents_in_order():
+    sup = LLMSupervisor({"AgentA": AgentA(), "AgentB": AgentB()})
+    result = sup.run("x")
+    assert result == "xab"
+    assert sup.context["order"] == ["A", "B"]
+
+
+def test_discover_agents_loads_custom_package(monkeypatch):
+    fakepkg = types.ModuleType("fakepkg")
+    fakepkg.__path__ = ["fake"]
+
+    mod1 = types.ModuleType("fakepkg.mod1")
+
+    class AgentX(Agent):
+        def act(self, message: str, context: dict):
+            return "x", context
+
+    mod1.AgentX = AgentX
+
+    mod2 = types.ModuleType("fakepkg.mod2")
+
+    class AgentY(Agent):
+        def act(self, message: str, context: dict):
+            return "y", context
+
+    mod2.AgentY = AgentY
+
+    monkeypatch.setitem(sys.modules, "fakepkg", fakepkg)
+    monkeypatch.setitem(sys.modules, "fakepkg.mod1", mod1)
+    monkeypatch.setitem(sys.modules, "fakepkg.mod2", mod2)
+
+    monkeypatch.setattr(pkgutil, "iter_modules", lambda path: [
+        types.SimpleNamespace(name="mod1"),
+        types.SimpleNamespace(name="mod2"),
+    ])
+
+    agents = discover_agents("fakepkg")
+    assert set(agents) == {"AgentX", "AgentY"}
+
+    sup = LLMSupervisor(agents)
+    assert sorted(sup.available_agents()) == ["AgentX", "AgentY"]
+
+
+class SummarizerStub(Agent):
+    def act(self, message: str, context: dict):
+        return "summary", context
+
+
+def test_advanced_supervisor_summarizes_history(monkeypatch):
+    responses = iter(["AgentA", "FINISH"])
+    lm_mod.generate_answer = lambda _: next(responses)
+    sup_mod.generate_answer = lm_mod.generate_answer
+
+    sup = AdvancedSupervisor(
+        {"AgentA": AgentA()},
+        max_history=1,
+        summarizer=SummarizerStub(),
+    )
+
+    sup.run("x")
+    assert sup.context["messages"] == [{"role": "system", "content": "summary"}]
+
+
+def test_advanced_supervisor_respects_max_turns(monkeypatch):
+    responses = iter(["AgentA", "AgentB", "AgentA"])
+    lm_mod.generate_answer = lambda _: next(responses)
+    sup_mod.generate_answer = lm_mod.generate_answer
+
+    sup = AdvancedSupervisor(
+        {"AgentA": AgentA(), "AgentB": AgentB()},
+        max_turns=2,
+        summarizer=SummarizerStub(),
+    )
+
+    sup.run("x")
+    assert sup.context["order"] == ["A", "B"]


### PR DESCRIPTION
## Summary
- implement `discover_agents` helper and enhance `LLMSupervisor`
- add supervisor docs in README
- extend supervisor tests for agent discovery
- add `AdvancedSupervisor` with history summarization & turn limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686abcce0acc8323a7300ecca231f997